### PR TITLE
DEV 

### DIFF
--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,7 +1,6 @@
-import {ChevronRight} from "lucide-react";
+import {notFound} from "next/navigation";
 
 import {api} from "@/api";
-import {H2, H3} from "@/components/typo";
 import {ProjectArticle} from "@/modules/projects/components/project-article";
 import {VerticalCarousel} from "@/components/vertical-carousel";
 import {Skeleton} from "@/components/ui/skeleton";
@@ -35,25 +34,28 @@ export async function generateMetadata({params: {slug}}: ProjectPageProps) {
 }
 
 export default async function ProjectPage({params: {slug}}: ProjectPageProps) {
+  const project = await api.projects.fetch(slug);
+
+  if (!project) {
+    return notFound();
+  }
+
+  const multimedia = [...project.imagenes, ...project.videos];
 
   return (
     <section className="container">
       <div className="flex flex-1 items-center">
-        <ul className="mx-2 flex-1">
-          {data.map((x) => (
-            <li key={x.id}>
-              <ProjectArticle project={x}>
-                <aside className="ms-16 w-vertical">
-                  {x.imagenes !== null ? (
-                    <VerticalCarousel images={[...x.imagenes, ...x.videos]} />
-                  ) : (
-                    <Skeleton className="h-[33.75rem] w-vertical" />
-                  )}
-                </aside>
-              </ProjectArticle>
-            </li>
-          ))}
-        </ul>
+        <div className="mx-2 flex-1">
+          <ProjectArticle project={project}>
+            <aside className="ms-16 w-vertical">
+              {project.imagenes !== null ? (
+                <VerticalCarousel images={multimedia} />
+              ) : (
+                <Skeleton className="h-[33.75rem] w-vertical" />
+              )}
+            </aside>
+          </ProjectArticle>
+        </div>
       </div>
     </section>
   );

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -6,8 +6,35 @@ import {ProjectArticle} from "@/modules/projects/components/project-article";
 import {VerticalCarousel} from "@/components/vertical-carousel";
 import {Skeleton} from "@/components/ui/skeleton";
 
-export default async function ProjectPage() {
+type ProjectPageProps = {
+  params: {
+    slug: string;
+  };
+};
+
+export async function generateStaticParams() {
   const {data} = await api.projects.get();
+
+  return data.map((p) => ({
+    slug: p.slug,
+  }));
+}
+
+export async function generateMetadata({params: {slug}}: ProjectPageProps) {
+  const project = await api.projects.fetch(slug);
+
+  if (!project) {
+    return notFound();
+  }
+
+  return {
+    title: project.nombre,
+    description: project.descripcion,
+    image: project.portada.url,
+  };
+}
+
+export default async function ProjectPage({params: {slug}}: ProjectPageProps) {
 
   return (
     <section className="container">

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,21 +1,19 @@
 import {api} from "@/api";
 import {H3} from "@/components/typo";
 import {ProductLink} from "@/modules/product";
-import {ProjectArticle} from "@/modules/projects/components/project-article";
 
 export default async function ProjectsPage() {
   const {data} = await api.projects.get();
 
   return (
     <section className="container flex border-e border-s">
-      <section className="flex-1 border-s">
-        <header className="w-full pb-2">
-          <H3 className="border-b py-3 text-center">Our Work</H3>
+      <section className="flex-1">
+        <header className="w-full border-b pb-0">
+          <H3 className="py-3 text-center">Our Work</H3>
         </header>
         <ul className="grid grid-cols-3 gap-10 py-8">
           {data.map((x) => (
             <li key={x.id} className="inline-flex max-w-[19rem] justify-self-center ">
-              {/* <ProjectArticle project={x}> */}
               <ProductLink path="projects" product={x} ratio={1} />
             </li>
           ))}

--- a/src/modules/projects/api.ts
+++ b/src/modules/projects/api.ts
@@ -28,6 +28,17 @@ export async function fetchProject(slug: string): Promise<Project | null> {
       `projects?filters[slug][$contains]=${slug}&populate[imagenes][fields][0]=name&populate[imagenes][fields][1]=url&populate[imagenes][fields][2]=hash&populate[videos][fields][0]=name&populate[videos][fields][1]=url&populate[videos][fields][2]=hash&populate[portada][fields][0]=name&populate[portada][fields][1]=url&populate[portada][fields][2]=hash`,
     );
 
+    const cpy = data;
+
+    data.forEach((x, idx) => {
+      cpy.splice(idx, 1, {
+        ...x,
+        portada: {...x.portada, url: STRAPI_HOST + x.portada.url},
+        imagenes: x.imagenes.map((x) => ({...x, url: STRAPI_HOST + x.url})),
+        videos: x.videos.map((x) => ({...x, url: STRAPI_HOST + x.url})),
+      });
+    });
+
     return data[0];
   } catch (error) {
     throw error;

--- a/src/modules/projects/api.ts
+++ b/src/modules/projects/api.ts
@@ -25,7 +25,7 @@ export async function getProjects(): QueryResponse<Project[]> {
 export async function fetchProject(slug: string): Promise<Project | null> {
   try {
     const {data} = await query<Project[]>(
-      `projects?filters[slug][$contains]=${slug}&populate[imagenes][fields][0]=name&populate[imagenes][fields][1]=url&populate[imagenes][fields][2]=hash&populate[portada][fields][0]=name&populate[portada][fields][1]=url&populate[portada][fields][2]=hash`,
+      `projects?filters[slug][$contains]=${slug}&populate[imagenes][fields][0]=name&populate[imagenes][fields][1]=url&populate[imagenes][fields][2]=hash&populate[videos][fields][0]=name&populate[videos][fields][1]=url&populate[videos][fields][2]=hash&populate[portada][fields][0]=name&populate[portada][fields][1]=url&populate[portada][fields][2]=hash`,
     );
 
     return data[0];

--- a/src/modules/projects/components/project-article.tsx
+++ b/src/modules/projects/components/project-article.tsx
@@ -1,11 +1,13 @@
 import {Link} from "next-view-transitions";
 import {BlocksRenderer, type BlocksContent} from "@strapi/blocks-react-renderer";
+import {ChevronLeft} from "lucide-react";
 
 import {Project} from "../types";
 
 import {H1, H2, H3, H4, P} from "@/components/typo";
 import {Button} from "@/components/ui/button";
 import {Whatsapp} from "@/components/icons/whatsapp";
+import {cn} from "@/lib/utils";
 
 type ProjectArticleProps = {
   project: Project;
@@ -17,8 +19,17 @@ export function ProjectArticle({project, children}: ProjectArticleProps) {
 
   return (
     <article className="border-e border-s">
-      <header className="flex justify-center gap-4 border-b">
-        <H2 className=" border-none py-6 text-3xl font-medium">{project.nombre}</H2>
+      <header className="flex items-center justify-between gap-4 border-b">
+        <Link
+          className={cn(
+            "group inline-flex items-center px-2 text-sm font-normal text-slate-800/65  hover:underline",
+          )}
+          href="/projects"
+        >
+          <ChevronLeft className="ms-2 size-4 stroke-1 transition-all duration-100 ease-in-out group-hover:inline-block group-hover:text-foreground" />
+          Atrás
+        </Link>
+        <H2 className="flex-1 border-none py-6 text-center text-4xl">{project.nombre}</H2>
       </header>
       <div className="inline-flex w-full gap-20 px-6 py-6">
         {children}


### PR DESCRIPTION
### `src/app/projects/[slug]/page.tsx`

- Se añadió el parámetro `slug` a `ProjectPage`.
- Se añadieron las funciones `generateStaticParams` y `generateMetaData`.
- Se cambió el `get` de los datos, anteriormente traía todos los proyectos, ahora trae un único proyecto correspondiente al `slug`.
- Se creó el array `multimedia` que une las imagenes y videos del proyecto.

### `src/modules/projects/api.ts`

- Se actualizó la query de `fetchProject()` para que también traiga los videos.
- Se añadió la url completa a los obj multimedia (portada, imagenes, videos).

### `src/app/projects/page.tsx`

- Se sacó el `border-s` de la segunda `<section />` ya que la primera también lo tiene y quedaba doble:
![image](https://github.com/user-attachments/assets/a3f785d1-e895-4e52-902a-990d5ffe1bed)

 Ahora se ve así:
![image](https://github.com/user-attachments/assets/ae415d8b-50a2-42c1-b448-66a0324ae945)


### `src/modules/projects/components/project-article.tsx`

- Se agregó un `<Link />` para volver a la sección **Our Work** (se puede implementar en `ProductPage` también).
![JAD-project-atras](https://github.com/user-attachments/assets/256558ef-e8ad-440c-9307-aaa453dcecf8)
