### PR TITLE
DEV-306/eliminar-routa-faqs

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -36,10 +36,6 @@ export function Header() {
               <span className="px-2 tracking-widest">Nuestro trabajo</span>
               <div className="h-[0.15rem] w-full bg-transparent transition-colors duration-100 ease-in-out group-hover:bg-amber-400/65" />
             </Link>
-            <Link className="group relative" href="/faqs">
-              <span className="px-2 tracking-widest">FAQs</span>
-              <div className="h-[0.15rem] w-full bg-transparent transition-colors duration-100 ease-in-out group-hover:bg-amber-400/65" />
-            </Link>
             <Link
               className="group relative"
               href="https://www.instagram.com/jad.marmoleria/"


### PR DESCRIPTION
Se eliminó el `<Link />` de FAQs del `<Header />`

![JAD-delete-faqs](https://github.com/user-attachments/assets/79c0197c-712e-4a19-874c-c30c48d4ba4c)
