### PR TITLE
Add cache tags

### DIFF
--- a/src/app/api/route.ts
+++ b/src/app/api/route.ts
@@ -1,24 +1,25 @@
-import {revalidatePath} from "next/cache";
+import {revalidatePath, revalidateTag} from "next/cache";
 import {NextRequest, NextResponse} from "next/server";
-
+import { Categories } from "@/modules/categories/enum";
 import {STRAPI_TOKEN} from "@/config";
+
+
 
 export async function POST(req: NextRequest) {
   const secret = req.headers.get("x-strapi-secret");
+  const body = await req.json();
+  const model = body.model;
 
   if (secret !== STRAPI_TOKEN) {
     return NextResponse.json({message: "Invalid token"}, {status: 401});
   }
 
   try {
-    revalidatePath("/");
-    revalidatePath("/products");
-    revalidatePath("/products/[slug]", "page");
-    revalidatePath("/projects");
-    revalidatePath("/projects/[slug]", "page");
-
+    revalidateTag(model);
     return NextResponse.json({revalidated: true});
   } catch (err) {
     return NextResponse.json({error: "Error revalidating"}, {status: 500});
   }
+
 }
+

--- a/src/lib/strapi/core.ts
+++ b/src/lib/strapi/core.ts
@@ -2,12 +2,13 @@ import type {QueryResponse} from "./types";
 
 import {STRAPI_HOST, STRAPI_TOKEN} from "@/config";
 
-export async function query<T>(path: string): QueryResponse<T> {
+export async function query<T>(path: string, options?: RequestInit): QueryResponse<T> {
   const url = `${STRAPI_HOST}/api/${path}`;
   const prom = await fetch(url, {
     headers: {
       Authorization: `Bearer ${STRAPI_TOKEN}`,
     },
+    ...options,
   });
 
   const res = await prom.json();

--- a/src/modules/categories/aplication/api.ts
+++ b/src/modules/categories/aplication/api.ts
@@ -5,7 +5,7 @@ import {Api, query, QueryResponse} from "@/lib/strapi";
 async function getAplications(): QueryResponse<Aplication[]> {
   const res = await query<Aplication[]>(
     "applications?populate[fields][0]=nombre&populate[fields][1]=slug",
-  );
+    { next: { tags: ['application'] } });
 
   return res;
 }

--- a/src/modules/categories/color/api.ts
+++ b/src/modules/categories/color/api.ts
@@ -3,7 +3,7 @@ import {Color} from "./types";
 import {Api, query, QueryResponse} from "@/lib/strapi";
 
 async function getColors(): QueryResponse<Color[]> {
-  const res = await query<Color[]>("colors?populate[fields][0]=nombre&populate[fields][1]=slug");
+  const res = await query<Color[]>("colors?populate[fields][0]=nombre&populate[fields][1]=slug", { next: { tags: ['color'] } });
 
   return res;
 }

--- a/src/modules/categories/material/api.ts
+++ b/src/modules/categories/material/api.ts
@@ -5,7 +5,7 @@ import {Api, query, QueryResponse} from "@/lib/strapi";
 async function getMaterials(): QueryResponse<Material[]> {
   const res = await query<Material[]>(
     "materials?populate[fields][0]=nombre&populate[fields][1]=slug",
-  );
+    { next: { tags: ['material'] } });
 
   return res;
 }

--- a/src/modules/categories/use/api.ts
+++ b/src/modules/categories/use/api.ts
@@ -3,7 +3,7 @@ import {Use} from "./types";
 import {Api, query, QueryResponse} from "@/lib/strapi";
 
 async function getUses(): QueryResponse<Use[]> {
-  const res = await query<Use[]>("usos?populate[fields][0]=nombre&populate[fields][1]=slug");
+  const res = await query<Use[]>("usos?populate[fields][0]=nombre&populate[fields][1]=slug", { next: { tags: ['uso'] } });
 
   return res;
 }

--- a/src/modules/content/hero/api.ts
+++ b/src/modules/content/hero/api.ts
@@ -19,7 +19,7 @@ export async function fetchHero(): QueryResponse<Hero> {
   try {
     const res = await query<Hero>(
       "hero?populate[imagenes][fields][0]=name&populate[imagenes][fields][1]=url",
-    );
+      { next: { tags: ['hero'] } });
 
     return res;
   } catch (error) {

--- a/src/modules/product/api.ts
+++ b/src/modules/product/api.ts
@@ -7,7 +7,7 @@ import {Api, Image, query, type QueryResponse} from "@/lib/strapi";
 async function getProducts(): QueryResponse<Product[]> {
   const res = await query<Product[]>(
     "products?populate[usos][fields][0]=nombre&populate[usos][fields][1]=slug&populate[portada][fields][0]=name&populate[portada][fields][1]=url&populate[portada][fields][2]=hash&fields[0]=nombre&fields[1]=slug&fields[2]=descripcion&fields[3]=espesor&fields[4]=disponibilidad&status=published",
-  );
+    { next: { tags: ['product'] } });
 
   const cpy = res;
 
@@ -22,7 +22,7 @@ async function fetchProduct(slug: string): Promise<Product | null> {
   try {
     const {data} = await query<Product[]>(
       `products?filters[slug][$contains]=${slug}&populate[usos][fields][0]=nombre&populate[usos][fields][1]=slug&populate[aplicaciones][fields][0]=nombre&populate[aplicaciones][fields][1]=slug&populate[material][fields][0]=nombre&populate[material][fields][1]=slug&populate[imagenes][fields][0]=name&populate[imagenes][fields][1]=url&populate[imagenes][fields][2]=hash&populate[portada][fields][0]=name&populate[portada][fields][1]=url&populate[portada][fields][2]=hash`,
-    );
+      { next: { tags: ['product'] } });
 
     return data[0];
   } catch (error) {
@@ -48,7 +48,7 @@ export async function fetchProductByCategory(category: string, value: string): P
   try {
     const {data} = await query<Product[]>(
       `products?filters[${category}][slug][$contains]=${value}&populate[usos][fields][0]=nombre&populate[usos][fields][1]=slug&populate[imagenes][fields][0]=name&populate[imagenes][fields][1]=url&populate[imagenes][fields][2]=hash&populate[portada][fields][0]=name&populate[portada][fields][1]=url&populate[portada][fields][2]=hash`,
-    );
+      { next: { tags: ['product'] } });
 
     const cpy = data;
 

--- a/src/modules/projects/api.ts
+++ b/src/modules/projects/api.ts
@@ -6,7 +6,7 @@ import {STRAPI_HOST} from "@/config";
 export async function getProjects(): QueryResponse<Project[]> {
   const res = await query<Project[]>(
     "projects?populate[imagenes][fields][0]=name&populate[imagenes][fields][1]=url&populate[imagenes][fields][2]=hash&populate[videos][fields][0]=name&populate[videos][fields][1]=url&populate[videos][fields][2]=hash&populate[portada][fields][0]=name&populate[portada][fields][1]=url&populate[portada][fields][2]=hash",
-  );
+    { next: { tags: ['project'] } });
 
   const cpy = res;
 
@@ -26,7 +26,7 @@ export async function fetchProject(slug: string): Promise<Project | null> {
   try {
     const {data} = await query<Project[]>(
       `projects?filters[slug][$contains]=${slug}&populate[imagenes][fields][0]=name&populate[imagenes][fields][1]=url&populate[imagenes][fields][2]=hash&populate[videos][fields][0]=name&populate[videos][fields][1]=url&populate[videos][fields][2]=hash&populate[portada][fields][0]=name&populate[portada][fields][1]=url&populate[portada][fields][2]=hash`,
-    );
+      { next: { tags: ['project'] } });
 
     const cpy = data;
 


### PR DESCRIPTION
### Revalidación on-demand
Se modificó la revalidación de los datos, ahora en vez de revalidar todas las rutas en cualquier tipo de cambio, se hace en base a la tabla modificada por medio de los `revalidateTag`

![image](https://github.com/user-attachments/assets/744c8939-051f-40b0-b46a-f496337ac226)

> Ejemplo solo modificando la tabla Color


### Webhook

Se modificó para recibir solo los eventos **publish** y **unpublish** de las tablas

![image](https://github.com/user-attachments/assets/7f244271-4b2f-42f2-8390-dd2a2f743a4d)
