### PR TITLE
DEV-315/anadir-plugin-de-tailwind

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@eslint/compat": "^1.0.1",
     "@next/eslint-plugin-next": "^14.2.4",
+    "@tailwindcss/typography": "^0.5.16",
     "@types/node": "^20.12.12",
     "@types/react": "^18.3.3",
     "@types/react-dom": "^18.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,6 +78,9 @@ importers:
       '@next/eslint-plugin-next':
         specifier: ^14.2.4
         version: 14.2.15
+      '@tailwindcss/typography':
+        specifier: ^0.5.16
+        version: 0.5.16(tailwindcss@3.4.3)
       '@types/node':
         specifier: ^20.12.12
         version: 20.12.12
@@ -101,7 +104,7 @@ importers:
         version: 9.1.0(eslint@9.13.0(jiti@1.21.0))
       eslint-plugin-import:
         specifier: ^2.29.1
-        version: 2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0))
+        version: 2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@9.13.0(jiti@1.21.0))
       eslint-plugin-prettier:
         specifier: ^5.1.3
         version: 5.1.3(eslint-config-prettier@9.1.0(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0))(prettier@3.2.5)
@@ -687,6 +690,11 @@ packages:
 
   '@swc/helpers@0.5.5':
     resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
+
+  '@tailwindcss/typography@0.5.16':
+    resolution: {integrity: sha512-0wDLwCVF5V3x3b1SGXPCDcdsbDHMBe+lkFzBRaHeLvNi+nrrnZ1lA18u+OTWO8iSWU2GxUOCvlXtDuqftc1oiA==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
 
   '@types/estree@1.0.6':
     resolution: {integrity: sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==}
@@ -1981,6 +1989,12 @@ packages:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
 
+  lodash.castarray@4.4.0:
+    resolution: {integrity: sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==}
+
+  lodash.isplainobject@4.0.6:
+    resolution: {integrity: sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==}
+
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
@@ -2240,6 +2254,10 @@ packages:
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.2.14
+
+  postcss-selector-parser@6.0.10:
+    resolution: {integrity: sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==}
+    engines: {node: '>=4'}
 
   postcss-selector-parser@6.0.13:
     resolution: {integrity: sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==}
@@ -3342,6 +3360,14 @@ snapshots:
       '@swc/counter': 0.1.3
       tslib: 2.6.2
 
+  '@tailwindcss/typography@0.5.16(tailwindcss@3.4.3)':
+    dependencies:
+      lodash.castarray: 4.4.0
+      lodash.isplainobject: 4.0.6
+      lodash.merge: 4.6.2
+      postcss-selector-parser: 6.0.10
+      tailwindcss: 3.4.3
+
   '@types/estree@1.0.6': {}
 
   '@types/json-schema@7.0.12': {}
@@ -3587,10 +3613,10 @@ snapshots:
       '@typescript-eslint/eslint-plugin': 7.8.0(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5)
       '@typescript-eslint/parser': 7.8.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5)
       eslint-config-prettier: 9.1.0(eslint@9.13.0(jiti@1.21.0))
-      eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0)))
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0))
+      eslint-import-resolver-alias: 1.1.2(eslint-plugin-import@2.29.1)
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@9.13.0(jiti@1.21.0))
       eslint-plugin-eslint-comments: 3.2.0(eslint@9.13.0(jiti@1.21.0))
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.8.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0))
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.8.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@9.13.0(jiti@1.21.0))
       eslint-plugin-jest: 27.9.0(@typescript-eslint/eslint-plugin@7.8.0(@typescript-eslint/parser@7.8.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5)
       eslint-plugin-jsx-a11y: 6.8.0(eslint@9.13.0(jiti@1.21.0))
       eslint-plugin-playwright: 1.6.0(eslint-plugin-jest@27.9.0(@typescript-eslint/eslint-plugin@7.8.0(@typescript-eslint/parser@7.8.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0))
@@ -4175,8 +4201,8 @@ snapshots:
       '@typescript-eslint/parser': 7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5)
       eslint: 9.13.0(jiti@1.21.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0))
-      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0))
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.13.0(jiti@1.21.0))
+      eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@9.13.0(jiti@1.21.0))
       eslint-plugin-jsx-a11y: 6.8.0(eslint@9.13.0(jiti@1.21.0))
       eslint-plugin-react: 7.34.1(eslint@9.13.0(jiti@1.21.0))
       eslint-plugin-react-hooks: 4.6.0(eslint@9.13.0(jiti@1.21.0))
@@ -4190,7 +4216,7 @@ snapshots:
     dependencies:
       eslint: 9.13.0(jiti@1.21.0)
 
-  eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0))):
+  eslint-import-resolver-alias@1.1.2(eslint-plugin-import@2.29.1):
     dependencies:
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0))
 
@@ -4202,12 +4228,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0)):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.13.0(jiti@1.21.0)):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 9.13.0(jiti@1.21.0)
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0))
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.13.0(jiti@1.21.0))
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0))
       fast-glob: 3.3.1
       get-tsconfig: 4.7.0
@@ -4219,12 +4245,12 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0)):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@9.13.0(jiti@1.21.0)):
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.15.0
       eslint: 9.13.0(jiti@1.21.0)
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.8.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0))
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.8.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.13.0(jiti@1.21.0))
       eslint-plugin-import: 2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0))
       fast-glob: 3.3.1
       get-tsconfig: 4.7.0
@@ -4236,25 +4262,25 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0)):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.13.0(jiti@1.21.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5)
       eslint: 9.13.0(jiti@1.21.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0))
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1)(eslint@9.13.0(jiti@1.21.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.8.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0)):
+  eslint-module-utils@2.8.0(@typescript-eslint/parser@7.8.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.13.0(jiti@1.21.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.8.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5)
       eslint: 9.13.0(jiti@1.21.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0))
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-plugin-import@2.29.1)(eslint@9.13.0(jiti@1.21.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -4264,7 +4290,7 @@ snapshots:
       eslint: 9.13.0(jiti@1.21.0)
       ignore: 5.2.4
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0)):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@9.13.0(jiti@1.21.0)):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -4274,7 +4300,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.13.0(jiti@1.21.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0))
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.13.0(jiti@1.21.0))
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -4301,7 +4327,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.13.0(jiti@1.21.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0))
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.13.0(jiti@1.21.0))
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -4318,7 +4344,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.8.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0)):
+  eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.8.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-typescript@3.6.1)(eslint@9.13.0(jiti@1.21.0)):
     dependencies:
       array-includes: 3.1.7
       array.prototype.findlastindex: 1.2.3
@@ -4328,7 +4354,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.13.0(jiti@1.21.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.8.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@7.8.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-plugin-import@2.29.1(@typescript-eslint/parser@7.10.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0)))(eslint@9.13.0(jiti@1.21.0))
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@7.8.0(eslint@9.13.0(jiti@1.21.0))(typescript@5.4.5))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.13.0(jiti@1.21.0))
       hasown: 2.0.0
       is-core-module: 2.13.1
       is-glob: 4.0.3
@@ -5001,6 +5027,10 @@ snapshots:
     dependencies:
       p-locate: 5.0.0
 
+  lodash.castarray@4.4.0: {}
+
+  lodash.isplainobject@4.0.6: {}
+
   lodash.merge@4.6.2: {}
 
   loose-envify@1.4.0:
@@ -5246,6 +5276,11 @@ snapshots:
     dependencies:
       postcss: 8.4.38
       postcss-selector-parser: 6.0.13
+
+  postcss-selector-parser@6.0.10:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
 
   postcss-selector-parser@6.0.13:
     dependencies:

--- a/src/modules/projects/components/project-article.tsx
+++ b/src/modules/projects/components/project-article.tsx
@@ -34,7 +34,9 @@ export function ProjectArticle({project, children}: ProjectArticleProps) {
       <div className="inline-flex w-full gap-20 px-6 py-6">
         {children}
         <div className="mx-auto max-w-3xl flex-1 space-y-6 ">
+          <div className="prose">
           <BlocksRenderer content={content} />
+          </div>
           <div className="inline-flex w-full justify-between">
             <footer className="self-end">
               <div className="flex justify-end py-6">

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -103,7 +103,7 @@ const config = {
       },
     },
   },
-  plugins: [require("tailwindcss-animate")],
+  plugins: [require("tailwindcss-animate"), require("@tailwindcss/typography")],
 } satisfies Config;
 
 export default config;


### PR DESCRIPTION
Se instaló un [@tailwindcss/typography plugin](https://github.com/tailwindcss/typography) para traer correctamente el estilo de la descripción de los proyectos.

### Descripción Strapi:

> ![image](https://github.com/user-attachments/assets/d0e9e104-28c4-48a3-9f4e-88a9d6cd991c)

### Web ahora:

> ![image](https://github.com/user-attachments/assets/cc3ff3d9-2272-450f-8004-f5f0acc418ef)

### Con plugin:

> ![image](https://github.com/user-attachments/assets/47fa5c0c-f230-415a-a6fe-6b2dd60a4e12)
