### PR TITLE
DEV-301/catalogo-proyectos

### DIFF
--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -47,7 +47,7 @@ export default async function ProjectPage({params: {slug}}: ProjectPageProps) {
       <div className="flex flex-1 items-center">
         <div className="mx-2 flex-1">
           <ProjectArticle project={project}>
-            <aside className="ms-16 w-vertical">
+            <aside className="m-auto lg:ms-16 lg:m-0 w-vertical">
               {project.imagenes !== null ? (
                 <VerticalCarousel images={multimedia} />
               ) : (

--- a/src/modules/projects/components/blocksrenderer-wrapper.tsx
+++ b/src/modules/projects/components/blocksrenderer-wrapper.tsx
@@ -1,0 +1,19 @@
+"use client";
+
+import { BlocksContent, BlocksRenderer } from "@strapi/blocks-react-renderer";
+import { Link } from "next-view-transitions";
+
+export function BlocksRendererWrapper({
+  content,
+}: {
+  content: BlocksContent;
+}) {
+  return (
+    <div className="prose pt-6 lg:pt-0">
+      <BlocksRenderer
+        content={content}
+        blocks={{link: ({ children, url }) => <Link href={url} target="_blank" rel="noopener noreferrer">{children}</Link>}}
+      />
+    </div>
+  );
+}

--- a/src/modules/projects/components/project-article.tsx
+++ b/src/modules/projects/components/project-article.tsx
@@ -1,6 +1,6 @@
 import {Link} from "next-view-transitions";
 import {BlocksRenderer, type BlocksContent} from "@strapi/blocks-react-renderer";
-import {ChevronLeft} from "lucide-react";
+import {ChevronDown, ChevronLeft} from "lucide-react";
 
 import {Project} from "../types";
 
@@ -8,6 +8,7 @@ import {H1, H2, H3, H4, P} from "@/components/typo";
 import {Button} from "@/components/ui/button";
 import {Whatsapp} from "@/components/icons/whatsapp";
 import {cn} from "@/lib/utils";
+import { BlocksRendererWrapper } from "./blocksrenderer-wrapper";
 
 type ProjectArticleProps = {
   project: Project;
@@ -16,28 +17,38 @@ type ProjectArticleProps = {
 
 export function ProjectArticle({project, children}: ProjectArticleProps) {
   const content: BlocksContent = project.descripcion as unknown as BlocksContent;
-
   return (
     <article className="border-e border-s">
       <header className="flex items-center justify-between gap-4 border-b">
         <Link
           className={cn(
-            "group inline-flex items-center px-2 text-sm font-normal text-slate-800/65  hover:underline",
+            "group inline-flex items-center px-2 text-sm font-normal text-slate-800/65 hover:underline",
           )}
           href="/projects"
         >
           <ChevronLeft className="ms-2 size-4 stroke-1 transition-all duration-100 ease-in-out group-hover:inline-block group-hover:text-foreground" />
           Atrás
         </Link>
-        <H2 className="flex-1 border-none py-6 text-center text-4xl">{project.nombre}</H2>
+        <H2 className="flex-1 border-none py-6 md:text-center text-4xl">{project.nombre}</H2>
       </header>
-      <div className="inline-flex w-full gap-20 px-6 py-6">
+      <div className="pt-4 lg:hidden flex flex-col items-center w-full gap-y-6">
+      <Button className="btn btn-primary ">
+           Sacate las dudas
+          <Link className="group relative" href="/" target="_blank">
+             <Whatsapp className="size-5" />
+          </Link>
+        </Button>
+        <Link className="text-sm inline-flex items-center font-normal text-slate-800/65" href='#descripcion'>Más información
+          <ChevronDown className="ms-1 size-4 stroke-1" />
+        </Link>
+      </div>
+      <div className="lg:inline-flex m-auto w-full gap-20 px-6 py-6">
         {children}
         <div className="mx-auto max-w-3xl flex-1 space-y-6 ">
-          <div className="prose">
-          <BlocksRenderer content={content} />
+          <div className="prose pt-6 lg:pt-0" id="descripcion">
+            <BlocksRendererWrapper content={content} />
           </div>
-          <div className="inline-flex w-full justify-between">
+          <div className="inline-flex w-full justify-center lg:justify-end">
             <footer className="self-end">
               <div className="flex justify-end py-6">
                 <Button className="btn btn-primary">


### PR DESCRIPTION
Se agregaron los estilos necesarios para el diseño responsive en '`projects/[slug]`'

![image](https://github.com/user-attachments/assets/48aaa0ba-6ddb-40e0-ac33-3dcdb9b2683a)

Se agregó un nuevo componente `<BlocksRendererWrapper />` para modificar el target de los links