### PR TITLE
DEV-311/agregar-numero-de-wpp-al-boton-de-contactanos

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -43,7 +43,7 @@ export function Header() {
             >
               <Instagram className="size-5" />
             </Link>
-            <Link className="group relative" href="/" target="_blank">
+            <Link className="group relative" href="https://wa.me/5491169101717" target="_blank">
               <Whatsapp className="size-5" />
             </Link>
           </div>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -52,15 +52,17 @@ export async function Hero() {
         <H1 className="">{titleComponent()}</H1>
         <P className={cn("text-xl text-muted-foreground", quicksand.className)}>{descripcion}</P>
         <div className="mt-8 inline-flex gap-2">
-          <Button className="w-48">
-            <Link href="https://wa.me/5491169101717" target="_blank" className="flex items-center gap-2">
+          <Link href="https://wa.me/5491169101717" target="_blank" className="flex items-center gap-2">
+            <Button className="w-48">
               Contactanos
               <Whatsapp className="size-7" />
-            </Link>
-          </Button>
-          <Button variant="outline">
-            <Link href="/products">Ver catálogo</Link>
-          </Button>
+              </Button>
+          </Link>
+          <Link href="/products">
+            <Button variant="outline">
+            Ver catálogo
+            </Button>
+          </Link>
         </div>
       </div>
     </section>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -52,9 +52,9 @@ export async function Hero() {
         <H1 className="">{titleComponent()}</H1>
         <P className={cn("text-xl text-muted-foreground", quicksand.className)}>{descripcion}</P>
         <div className="mt-8 inline-flex gap-2">
-          <Button className="w-48 ">
-            Contactanos
-            <Link href="#" target="_blank">
+          <Button className="w-48">
+            <Link href="https://wa.me/5491169101717" target="_blank" className="flex items-center gap-2">
+              Contactanos
               <Whatsapp className="size-7" />
             </Link>
           </Button>

--- a/src/modules/product/components/product-article.tsx
+++ b/src/modules/product/components/product-article.tsx
@@ -72,8 +72,8 @@ export function ProductArticle({product, children}: ProductArticleProps) {
             <footer className="self-end">
               <div className="flex justify-end py-6">
                 <Button className="btn btn-primary">
-                  Sacate las dudas
-                  <Link className="group relative" href="/" target="_blank">
+                  <Link className="group relative flex items-center gap-2" href="https://wa.me/5491169101717" target="_blank">
+                    Sacate las dudas
                     <Whatsapp className="size-5" />
                   </Link>
                 </Button>

--- a/src/modules/product/components/product-article.tsx
+++ b/src/modules/product/components/product-article.tsx
@@ -71,12 +71,12 @@ export function ProductArticle({product, children}: ProductArticleProps) {
             </ul>
             <footer className="self-end">
               <div className="flex justify-end py-6">
-                <Button className="btn btn-primary">
-                  <Link className="group relative flex items-center gap-2" href="https://wa.me/5491169101717" target="_blank">
-                    Sacate las dudas
+                <Link className="group relative flex items-center gap-2" href="https://wa.me/5491169101717" target="_blank">
+                  <Button className="btn btn-primary">
+                   Sacate las dudas
                     <Whatsapp className="size-5" />
-                  </Link>
-                </Button>
+                  </Button>
+                </Link>
               </div>
             </footer>
           </div>

--- a/src/modules/projects/components/project-article.tsx
+++ b/src/modules/projects/components/project-article.tsx
@@ -32,13 +32,13 @@ export function ProjectArticle({project, children}: ProjectArticleProps) {
         <H2 className="flex-1 border-none py-6 md:text-center text-4xl">{project.nombre}</H2>
       </header>
       <div className="pt-4 lg:hidden flex flex-col items-center w-full gap-y-6">
-        <Button className="btn btn-primary">
-           <Link className="group relative flex items-center gap-2" href="https://wa.me/5491169101717" target="_blank">
-             Sacate las dudas
+        <Link className="group relative flex items-center gap-2" href="https://wa.me/5491169101717" target="_blank">
+           <Button className="btn btn-primary">
+              Sacate las dudas
              <Whatsapp className="size-5" />
-           </Link>
-        </Button>
-        <Link className="text-sm inline-flex items-center font-normal text-slate-800/65" href='#descripcion'>Más información
+            </Button>
+         </Link>
+         <Link className="text-sm inline-flex items-center font-normal text-slate-800/65" href='#descripcion'>Más información
           <ChevronDown className="ms-1 size-4 stroke-1" />
         </Link>
       </div>
@@ -51,12 +51,12 @@ export function ProjectArticle({project, children}: ProjectArticleProps) {
           <div className="inline-flex w-full justify-center lg:justify-end">
             <footer className="self-end">
               <div className="flex justify-end py-6">
-                <Button className="btn btn-primary">
-                  <Link className="group relative flex items-center gap-2" href="https://wa.me/5491169101717" target="_blank">
+                <Link className="group relative flex items-center gap-2" href="https://wa.me/5491169101717" target="_blank">
+                  <Button className="btn btn-primary">
                     Sacate las dudas
                     <Whatsapp className="size-5" />
-                  </Link>
-                </Button>
+                  </Button>
+                </Link>
               </div>
             </footer>
           </div>

--- a/src/modules/projects/components/project-article.tsx
+++ b/src/modules/projects/components/project-article.tsx
@@ -52,8 +52,8 @@ export function ProjectArticle({project, children}: ProjectArticleProps) {
             <footer className="self-end">
               <div className="flex justify-end py-6">
                 <Button className="btn btn-primary">
-                  Sacate las dudas
-                  <Link className="group relative" href="/" target="_blank">
+                  <Link className="group relative flex items-center gap-2" href="https://wa.me/5491169101717" target="_blank">
+                    Sacate las dudas
                     <Whatsapp className="size-5" />
                   </Link>
                 </Button>

--- a/src/modules/projects/components/project-article.tsx
+++ b/src/modules/projects/components/project-article.tsx
@@ -32,11 +32,11 @@ export function ProjectArticle({project, children}: ProjectArticleProps) {
         <H2 className="flex-1 border-none py-6 md:text-center text-4xl">{project.nombre}</H2>
       </header>
       <div className="pt-4 lg:hidden flex flex-col items-center w-full gap-y-6">
-      <Button className="btn btn-primary ">
-           Sacate las dudas
-          <Link className="group relative" href="/" target="_blank">
+        <Button className="btn btn-primary">
+           <Link className="group relative flex items-center gap-2" href="https://wa.me/5491169101717" target="_blank">
+             Sacate las dudas
              <Whatsapp className="size-5" />
-          </Link>
+           </Link>
         </Button>
         <Link className="text-sm inline-flex items-center font-normal text-slate-800/65" href='#descripcion'>Más información
           <ChevronDown className="ms-1 size-4 stroke-1" />


### PR DESCRIPTION
Se modificó el `href` de cada link a WhatsApp para llevarte directo al chat de la marmolería, por el momento el número está puesto directamente en cada `href`.

También se modificó el orden de los componentes para que al tocar cualquier parte del botón funcione, antes solo funcionaba al tocar el icon de wp, y se agregaron estilos para que estos estén alineados (y se vea igual que antes).

>[!CAUTION]
>Me confundí y primero hice los **commits** directo en la rama `dev`, los descommitee pero no sé si realmente funcionó.


>[!NOTE]
>En los primeros commits el orden los componentes era
  `<Button >`
      texto
    `<Link />`
  `<Button />`
>pero después me di cuenta que no funcionaba si tocabas una parte del boton que no fuese el texto ni el icon, la segunda tanda de commits son solucionando eso 🤙

