### PR TITLE
DEV-304/producto-individual

### DIFF
--- a/src/app/products/[slug]/page.tsx
+++ b/src/app/products/[slug]/page.tsx
@@ -56,13 +56,11 @@ export default async function ProductPage({params: {slug}}: ProductPageProps) {
   return (
     <>
       <section className="container">
-        {/* <BackButton className="" /> */}
         <div className="flex flex-1 items-center">
-          {/* <NavProductButton path="tundra-dark" variant="prev" /> */}
-          <NavProductButton mode="back" variant="left" />
+          <NavProductButton className="hidden lg:block" mode="back" variant="left" />
           <div className="mx-12 flex-1">
-            <ProductArticle product={product}>
-              <aside className="ms-16 w-vertical">
+            <ProductArticle nextProduct={nextProduct} product={product}>
+              <aside className="m-auto w-vertical lg:ms-16">
                 {product.imagenes !== null ? (
                   <VerticalCarousel images={apiImages} />
                 ) : (
@@ -71,7 +69,7 @@ export default async function ProductPage({params: {slug}}: ProductPageProps) {
               </aside>
             </ProductArticle>
           </div>
-          <NavProductButton path={nextProduct.slug} variant="right" />
+          <NavProductButton className="hidden lg:block" path={nextProduct.slug} variant="right" />
         </div>
       </section>
       <aside className="border-t">

--- a/src/components/nav-button.tsx
+++ b/src/components/nav-button.tsx
@@ -8,7 +8,7 @@ import {Button} from "./ui/button";
 import {cn} from "@/lib/utils";
 
 type NavProductButtonProps = {
-  variant: "left" | "right";
+  variant: "left" | "right" | "leftString" | "rightString";
   path?: string;
   className?: string;
   mode?: "path" | "back";
@@ -17,6 +17,16 @@ type NavProductButtonProps = {
 const variants = {
   left: <ChevronLeft />,
   right: <ChevronRight />,
+  leftString: (
+    <>
+      <ChevronLeft /> Anterior
+    </>
+  ),
+  rightString: (
+    <>
+      Siguiente <ChevronRight />
+    </>
+  ),
 };
 
 export function NavProductButton({

--- a/src/modules/product/components/product-article.tsx
+++ b/src/modules/product/components/product-article.tsx
@@ -18,8 +18,17 @@ type ProductArticleProps = {
 export function ProductArticle({product, children}: ProductArticleProps) {
   return (
     <article className="border-e border-s">
-      <header className="flex justify-center gap-4 border-b">
-        <H2 className="border-none py-6 text-4xl">{product.nombre}</H2>
+      <header className="relative flex items-center border-b">
+        <Link
+          className={cn(
+            "group absolute left-0 inline-flex items-center gap-1 px-2 text-sm font-normal text-slate-800/65 hover:underline",
+          )}
+          href="/products"
+        >
+          <ChevronLeft className="ms-2 mt-icon size-4 stroke-1 transition-all duration-100 ease-in-out group-hover:inline-block group-hover:text-foreground" />
+          Atrás
+        </Link>
+        <H2 className="flex-grow border-none py-6 text-center text-4xl">{product.nombre}</H2>
       </header>
       <div className="inline-flex w-full gap-20 px-6 py-6">
         {children}

--- a/src/modules/product/components/product-article.tsx
+++ b/src/modules/product/components/product-article.tsx
@@ -1,6 +1,7 @@
 import type {Product} from "@/modules/product";
 
 import {Link} from "next-view-transitions";
+import {ChevronDown, ChevronLeft} from "lucide-react";
 
 import {H2, P} from "@/components/typo";
 import {Button} from "@/components/ui/button";
@@ -49,12 +50,23 @@ export function ProductArticle({product, children, nextProduct}: ProductArticleP
             variant="rightString"
           />
         </div>
-      <div className="inline-flex w-full gap-20 px-6 py-6">
+        <Link href="/" target="_blank">
+          <Button className="btn btn-primary ">
+            Sacate las dudas
+            <Whatsapp className="size-5" />
+          </Button>
+        </Link>
+        <Link
+          className="inline-flex items-center text-sm font-normal text-slate-800/65"
+          href="#descripcion"
+        >
+          Más información
+          <ChevronDown className="ms-1 size-4 stroke-1" />
+        </Link>
+      </div>
+      <div className="m-auto w-full gap-20 px-6 py-6 lg:inline-flex">
         {children}
-        <div className="mx-auto max-w-2xl flex-1 space-y-6 ">
-          {/* <P className="text-xl font-medium">
-            {product.nombre} - {product.publishedAt}
-          </P> */}
+        <div className="mx-auto max-w-2xl flex-1 space-y-6 pt-6 lg:pt-0" id="descripcion">
           <P className="text-pretty">{product.descripcion}</P>
           <div className="space-y-3 text-muted-foreground">
             <P className="w-72 rounded bg-muted px-6">
@@ -69,8 +81,8 @@ export function ProductArticle({product, children, nextProduct}: ProductArticleP
               {product.disponibilidad ? "sin stock" : "en stock"}
             </P>
           </div>
-          <div className="inline-flex w-full justify-between">
-            <ul className="flex max-w-md flex-wrap gap-4">
+          <div className="inline-flex w-full flex-col justify-between space-y-6">
+            <ul className="flex flex-wrap gap-4 lg:max-w-md">
               {product.usos!.map((uso) => (
                 <li
                   key={uso.id}
@@ -97,7 +109,7 @@ export function ProductArticle({product, children, nextProduct}: ProductArticleP
                 </li>
               ))}
             </ul>
-            <footer className="self-end">
+            <footer className="self-center lg:self-end">
               <div className="flex justify-end py-6">
                 <Button className="btn btn-primary">
                   <Link className="group relative flex items-center gap-2" href="https://wa.me/5491169101717" target="_blank">

--- a/src/modules/product/components/product-article.tsx
+++ b/src/modules/product/components/product-article.tsx
@@ -5,17 +5,18 @@ import {Link} from "next-view-transitions";
 import {H2, P} from "@/components/typo";
 import {Button} from "@/components/ui/button";
 import {cn} from "@/lib/utils";
-import {quicksand} from "@/fonts";
 import {Whatsapp} from "@/components/icons/whatsapp";
 import {IconLink} from "@/components/icon-link";
 import {IconNames} from "@/components/icons";
+import {NavProductButton} from "@/components/nav-button";
 
 type ProductArticleProps = {
   product: Product;
   children?: React.ReactNode;
+nextProduct?: Product;
 };
 
-export function ProductArticle({product, children}: ProductArticleProps) {
+export function ProductArticle({product, children, nextProduct}: ProductArticleProps) {
   return (
     <article className="border-e border-s">
       <header className="relative flex items-center border-b">
@@ -30,6 +31,24 @@ export function ProductArticle({product, children}: ProductArticleProps) {
         </Link>
         <H2 className="flex-grow border-none py-6 text-center text-4xl">{product.nombre}</H2>
       </header>
+      <div className="flex w-full flex-col items-center gap-y-6 pt-4 lg:hidden">
+        <div className="flex w-full justify-between px-4">
+          <NavProductButton
+            className={cn(
+              "w-auto text-base font-normal text-slate-800/80 hover:bg-transparent hover:underline",
+            )}
+            mode="back"
+            variant="leftString"
+          />
+          <NavProductButton
+            className={cn(
+              "w-auto text-base font-normal text-slate-800/80 hover:bg-transparent hover:underline",
+            )}
+            mode="path"
+            path={nextProduct?.slug}
+            variant="rightString"
+          />
+        </div>
       <div className="inline-flex w-full gap-20 px-6 py-6">
         {children}
         <div className="mx-auto max-w-2xl flex-1 space-y-6 ">

--- a/src/modules/projects/components/project-article.tsx
+++ b/src/modules/projects/components/project-article.tsx
@@ -22,11 +22,11 @@ export function ProjectArticle({project, children}: ProjectArticleProps) {
       <header className="flex items-center justify-between gap-4 border-b">
         <Link
           className={cn(
-            "group inline-flex items-center px-2 text-sm font-normal text-slate-800/65 hover:underline",
+            "group inline-flex items-center gap-1 px-2 text-sm font-normal text-slate-800/65 hover:underline",
           )}
           href="/projects"
         >
-          <ChevronLeft className="ms-2 size-4 stroke-1 transition-all duration-100 ease-in-out group-hover:inline-block group-hover:text-foreground" />
+          <ChevronLeft className="ms-2 mt-icon size-4 stroke-1 transition-all duration-100 ease-in-out group-hover:inline-block group-hover:text-foreground" />
           Atrás
         </Link>
         <H2 className="flex-1 border-none py-6 md:text-center text-4xl">{project.nombre}</H2>


### PR DESCRIPTION
### ProductArticle component
Se hicieron las modificaciones necesarias para implementar el diseño responsive, para esto se ocultó la navegación entre productos por fuera (**products/[slug]**) y se agrego una dentro. Además se agregó otro `<Link />` a WhatsAppy el `<Link />` Más información (como en los proyectos individuales).

### NavProductButton component
Para implementar la navegación por dentro de **ProductArticle** se agregaron nuevas variantes para mostrar tanto el ícono como un string ej: < Anterior

### products/[slug] 
Mínimas actualizaciones para implementar el diseño responsive.

### ProjectArticle component
Minima actualización del `<Link />` Atrás para que sea el mismo que se utiliza en `<ProductArticle />` (diseño más lindo)

### Visualizacion de los updates:

![{2C5DE35F-54DE-4DFC-9F9B-45945BDA6AA6}](https://github.com/user-attachments/assets/0736beff-f96b-4cda-aa23-84c8b25ad7d9)

![{6EDD83E2-11AA-4011-B815-DC8352968B51}](https://github.com/user-attachments/assets/7fca47ad-abb9-4fc4-99cc-f9e022c6c22b)
