### PR TITLE
DEV-305/home

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -17,7 +17,7 @@ export default async function HomePage() {
   const aplications = await api.aplications.get();
 
   return (
-    <section className="m-auto mx-auto pt-8">
+    <section className="m-auto mx-auto p-8 lg:pt-8">
       <Hero />
       <div className="m-auto max-w-5xl">
         <H2 className={cn("mb-8 border-none text-center leading-[3.2rem]")}>
@@ -28,7 +28,7 @@ export default async function HomePage() {
           </div>
           Encontrá el marmol que buscas según tus necesidades
         </H2>
-        <ul className="mx-auto flex max-w-xl flex-wrap justify-evenly gap-8">
+        <ul className="mx-auto flex max-w-xl flex-wrap justify-center gap-8 lg:justify-evenly">
           {usos.data.map((uso) => (
             <li
               key={uso.id}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -28,7 +28,7 @@ export default async function HomePage() {
           </div>
           Encontrá el marmol que buscas según tus necesidades
         </H2>
-        <ul className="mx-auto flex max-w-xl flex-wrap justify-center gap-8 lg:justify-evenly">
+        <ul className="mx-auto flex max-w-xl flex-wrap justify-evenly gap-8">
           {usos.data.map((uso) => (
             <li
               key={uso.id}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -69,7 +69,7 @@ export default async function HomePage() {
         <H2 className="mb-8 border-none text-center">
           Algunos de nuestros productos más solicitados
         </H2>
-        <ul className="flex flex-wrap justify-between gap-8 pb-12">
+        <ul className="flex flex-wrap justify-center gap-8 pb-12 lg:justify-between">
           {products.data.map((product) => (
             <li key={product.id} className="inline-flex">
               <ProductLink product={product} />

--- a/src/app/products/[slug]/page.tsx
+++ b/src/app/products/[slug]/page.tsx
@@ -58,7 +58,7 @@ export default async function ProductPage({params: {slug}}: ProductPageProps) {
       <section className="container">
         <div className="flex flex-1 items-center">
           <NavProductButton className="hidden lg:block" mode="back" variant="left" />
-          <div className="mx-12 flex-1">
+          <div className="flex-1 lg:mx-12">
             <ProductArticle nextProduct={nextProduct} product={product}>
               <aside className="m-auto w-vertical lg:ms-16">
                 {product.imagenes !== null ? (

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -85,7 +85,7 @@ export default async function ProductsPage({searchParams: {category, value}}: Pr
   };
 
   return (
-    <section className="flex w-full max-w-xl flex-col overflow-hidden border-e border-s lg:mx-auto lg:max-w-[88rem] lg:flex-row">
+    <section className="flex w-full flex-col overflow-hidden border-e border-s lg:mx-auto lg:max-w-[88rem] lg:flex-row">
       <aside className="flex flex-col lg:h-full lg:w-[250px] w-full pt-6 lg:py-6">
         <div className="border-b lg:w-auto flex flex-row gap-4 lg:gap-0 lg:justify-between">
           <H3 className="ml-3">Filtros</H3>

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -85,7 +85,7 @@ export default async function ProductsPage({searchParams: {category, value}}: Pr
   };
 
   return (
-    <section className="w-full mx-auto max-w-xl sm:max-w-2xl overflow-hidden md:max-w-5xl lg:max-w-[88rem] flex flex-col lg:flex-row border-e border-s">
+    <section className="flex w-full max-w-xl flex-col overflow-hidden border-e border-s lg:mx-auto lg:max-w-[88rem] lg:flex-row">
       <aside className="flex flex-col lg:h-full lg:w-[250px] w-full pt-6 lg:py-6">
         <div className="border-b lg:w-auto flex flex-row gap-4 lg:gap-0 lg:justify-between">
           <H3 className="ml-3">Filtros</H3>

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -45,7 +45,7 @@ export default async function ProjectPage({params: {slug}}: ProjectPageProps) {
   return (
     <section className="container">
       <div className="flex flex-1 items-center">
-        <div className="mx-2 flex-1">
+        <div className="flex-1 lg:mx-2">
           <ProjectArticle project={project}>
             <aside className="m-auto lg:ms-16 lg:m-0 w-vertical">
               {project.imagenes !== null ? (

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -6,7 +6,7 @@ export default async function ProjectsPage() {
   const {data} = await api.projects.get();
 
   return (
-    <section className="container flex border-e border-s">
+    <section className="container flex lg:border-e lg:border-s">
       <section className="flex-1">
         <header className="w-full border-b pb-0">
           <H3 className="py-3 text-center">Our Work</H3>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -48,7 +48,7 @@ export async function Hero() {
           </div>
         </div>
       </div>
-      <div className="m-auto mt-24 max-w-lg lg:pt-36">
+      <div className="m-auto mt-24 max-w-lg lg:m-0  lg:pt-36">
         <H1 className="">{titleComponent()}</H1>
         <P className={cn("text-xl text-muted-foreground", quicksand.className)}>{descripcion}</P>
         <div className="mt-8 inline-flex gap-2">

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -34,8 +34,8 @@ export async function Hero() {
   const p3 = imagenes[2];
 
   return (
-    <section className="mb-8 inline-flex h-[750px] w-full justify-center">
-      <div className="max-w-[52rem] flex-1">
+    <section className="mb-8 inline-flex h-[38rem] w-full justify-center p-2 lg:h-[750px] lg:p-0">
+      <div className="hidden max-w-[52rem] flex-1 lg:block">
         <div className="relative inline-flex gap-2">
           <div className={cn("absolute -z-20 h-[600px] w-[300px] rounded bg-blue-200")}>
             <img alt={p2.name} className="h-full rounded object-cover" src={p2.url} />
@@ -48,7 +48,7 @@ export async function Hero() {
           </div>
         </div>
       </div>
-      <div className="max-w-lg pt-36">
+      <div className="m-auto mt-24 max-w-lg lg:pt-36">
         <H1 className="">{titleComponent()}</H1>
         <P className={cn("text-xl text-muted-foreground", quicksand.className)}>{descripcion}</P>
         <div className="mt-8 inline-flex gap-2">
@@ -56,7 +56,7 @@ export async function Hero() {
             <Button className="w-48">
               Contactanos
               <Whatsapp className="size-7" />
-             </Button>
+            </Button>
           </Link>
           <Link href="/products">
             <Button variant="outline">


### PR DESCRIPTION
### HOME

Se ocultaron las imágenes de los productos en el Hero para facilitar la verticalización de la home y obtener un diseño más simple en mobile.
Se centraron todos los componentes.

**Muestra:**

![{D9C6C8E7-7A9D-49AF-A903-D51D936EF4B4}](https://github.com/user-attachments/assets/039fc250-ba00-4042-84d8-29656081b5ad)

![{06473636-22A3-4773-9561-B1A149118698}](https://github.com/user-attachments/assets/e59ac7c1-3478-4d8f-adce-014fe60d8594)



### Producto / Proyecto Individual

Se modificaron los `mx-2` para que se apliquen en `lg`, de esta forma, en pantallas medianas/chicas no tiene los bordes a los costados 

**Antes:**
![{07B80E4C-64B2-4169-9979-E2FC80DBCEE6}](https://github.com/user-attachments/assets/1ad383a9-e48d-4c02-9a55-e8b43ab19e72)

**Ahora:**
![{64171469-BEBC-4611-BC49-1B4E1CC226ED}](https://github.com/user-attachments/assets/bf9cedff-fcc0-43aa-a841-1dfed7946f1f)



### Catálogo Proyectos

Se modificaron los bordes para que se apliquen en `lg` por las mismas razones mencionadas anteriormente.



### Catálogo Productos

Se eliminaron los `max-w` aplicados para las pantallas medianas/chicas y así eliminar los bordes indeseados.