### PR TITLE
DEV-336/implementar-responsive-en-dimension-laptop

### DIFF
--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -35,20 +35,20 @@ export async function Hero() {
 
   return (
     <section className="mb-8 inline-flex h-[38rem] w-full justify-center p-2 lg:h-[750px] lg:p-0">
-      <div className="hidden max-w-[52rem] flex-1 lg:block">
+      <div className="hidden flex-1 lg:block lg:max-w-lg xl:max-w-2xl 2xl:max-w-[52rem]">
         <div className="relative inline-flex gap-2">
           <div className={cn("absolute -z-20 h-[600px] w-[300px] rounded bg-blue-200")}>
             <img alt={p2.name} className="h-full rounded object-cover" src={p2.url} />
           </div>
-          <div className="absolute left-60 top-10 -z-10 h-[600px] w-[300px] rounded bg-blue-400">
+          <div className="absolute left-36 top-10 -z-10 h-[600px] w-[300px] rounded bg-blue-400 xl:left-40 2xl:left-60">
             <img alt={p1.name} className="h-full rounded object-cover" src={p1.url} />
           </div>
-          <div className="absolute left-[30rem] top-20 z-0 h-[600px] w-[300px] rounded bg-blue-600">
+          <div className="absolute left-80 top-20 z-0 hidden h-[600px] w-[300px] rounded bg-blue-600 xl:block 2xl:left-[30rem]">
             <img alt={p3.name} className="h-full rounded object-cover" src={p3.url} />
           </div>
         </div>
       </div>
-      <div className="m-auto mt-24 max-w-lg lg:m-0  lg:pt-36">
+      <div className="m-auto mt-24 max-w-lg lg:m-0 lg:pl-6 lg:pt-36 xl:pl-0">
         <H1 className="">{titleComponent()}</H1>
         <P className={cn("text-xl text-muted-foreground", quicksand.className)}>{descripcion}</P>
         <div className="mt-8 inline-flex gap-2">


### PR DESCRIPTION
Actualizacion del `<Hero />` para mejorar el responsive en laptops

**Ejemplos:**

![{80B5E3A6-D15A-40EE-818B-33F1EE96004E}](https://github.com/user-attachments/assets/bd5312ec-eac1-43d6-b0ba-daa02cc456bd)

![{5EC3D720-4626-4824-A7F8-B9A5830232A4}](https://github.com/user-attachments/assets/5b6b486e-bee8-48bb-a617-60faf62d7a1e)

![{73338F38-F746-4284-B439-CE24C2469C2D}](https://github.com/user-attachments/assets/ea0eaccb-370f-49fa-aed9-5521f9eaafd9)

> Extension: Responsive viewer