### PR TITLE
DEV-337/solucionar-zoom-en-mobile

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,13 +18,14 @@ import {IconNames} from "@/components/icons";
 import {Categories} from "@/modules/categories/enum";
 
 export default async function HomePage() {
-  const products = await api.products.get();
+  const {data} = await api.products.get();
+  const products = data.slice(0, 3);
   const usos = await api.uses.get();
   const aplications = await api.aplications.get();
   const faqs = await api.faqs.get();
 
   return (
-    <section className="m-auto mx-auto p-8 lg:pt-8">
+    <section className="m-auto mx-auto p-4 lg:pt-8">
       <Hero />
       <div className="m-auto max-w-5xl">
         <H2 className={cn("mb-8 border-none text-center leading-[3.2rem]")}>
@@ -77,9 +78,9 @@ export default async function HomePage() {
           Algunos de nuestros productos más solicitados
         </H2>
         <ul className="flex flex-wrap justify-center gap-8 pb-12 lg:justify-between">
-          {products.data.map((product) => (
+          {products.map((product) => (
             <li key={product.id} className="inline-flex">
-              <ProductLink product={product} />
+              <ProductLink className="w-vertical" product={product} />
             </li>
           ))}
         </ul>

--- a/src/app/products/[slug]/page.tsx
+++ b/src/app/products/[slug]/page.tsx
@@ -73,7 +73,7 @@ export default async function ProductPage({params: {slug}}: ProductPageProps) {
         </div>
       </section>
       <aside className="flex justify-center border-t">
-        <div className="mx-24 flex max-w-lg flex-col justify-center sm:max-w-2xl md:max-w-3xl lg:max-w-5xl">
+        <div className="mx-4 flex max-w-lg flex-col justify-center sm:max-w-2xl md:mx-12 md:max-w-3xl lg:mx-24 lg:max-w-5xl">
           <H3 className="my-6 text-center text-2xl font-medium">
             Productos que podrían interesarte
           </H3>

--- a/src/app/products/page.tsx
+++ b/src/app/products/page.tsx
@@ -130,7 +130,7 @@ export default async function ProductsPage({searchParams: {category, value}}: Pr
        </div>
        <div className="hidden lg:block">
         {filters.map((filter) => (
-            <div className="gap-8 py-4">
+            <div key={filter.slug} className="gap-8 py-4">
               <h4 className="border-b font-medium">
                 <span className="px-3">{filter.title}</span>
               </h4>
@@ -145,13 +145,13 @@ export default async function ProductsPage({searchParams: {category, value}}: Pr
           ))}
        </div>
       </aside>
-      <section className="lg:flex-1 lg:border-s">
+      <section className="flex-1 lg:border-s">
         <H3 className="border-b py-3 text-center">{title()}</H3>
         {category && value ? (
           <ul className="flex flex-wrap justify-evenly gap-4 py-8">
             {filterProds.map((product) => (
               <li key={product.id} className="inline-flex">
-                <ProductLink product={product} ratio={1} />
+                <ProductLink className="w-vertical" product={product} ratio={1} />
               </li>
             ))}
           </ul>
@@ -159,7 +159,7 @@ export default async function ProductsPage({searchParams: {category, value}}: Pr
           <ul className="grid gap-12 py-8 md:grid-cols-2 lg:grid-cols-3">
             {products.data.map((product) => (
               <li key={product.id} className="inline-flex max-w-[19rem] justify-self-center">
-                <ProductLink product={product} ratio={1} />
+                <ProductLink className="w-vertical" product={product} ratio={1} />
               </li>
             ))}
           </ul>

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -9,7 +9,7 @@ import {quicksand} from "@/fonts";
 export function Header() {
   return (
     <div className="h-auto w-full border-b">
-      <header className="flex h-min w-full justify-center overflow-hidden px-28 py-3 backdrop-blur">
+      <header className="flex h-min w-full justify-center overflow-hidden px-4 py-3 backdrop-blur md:px-12 lg:px-28">
         <nav
           className={cn(
             "relative flex max-w-5xl flex-1 flex-col justify-center overflow-hidden rounded p-0 py-1",
@@ -20,7 +20,7 @@ export function Header() {
           </Link>
           <div
             className={cn(
-              "m-auto inline-flex w-full max-w-3xl justify-center gap-4 rounded py-1 font-semibold",
+              "m-auto inline-flex w-full max-w-3xl justify-center gap-2 rounded py-1 font-semibold md:gap-4",
               quicksand.className,
             )}
           >

--- a/src/components/vertical-image.tsx
+++ b/src/components/vertical-image.tsx
@@ -12,7 +12,7 @@ export function VerticalImage({alt, src, className, ratio = 9 / 16}: VerticalIma
   const multimedia = isImageOrVideo(src);
 
   return (
-    <div className={cn("w-vertical", className)}>
+    <div className={cn("w-full p-2 md:w-vertical", className)}>
       <AspectRatio ratio={ratio}>
         {multimedia === "image" ? (
           <img alt={alt} className="h-full w-full object-cover" src={src} />

--- a/src/modules/product/components/product-article.tsx
+++ b/src/modules/product/components/product-article.tsx
@@ -19,7 +19,7 @@ nextProduct?: Product;
 
 export function ProductArticle({product, children, nextProduct}: ProductArticleProps) {
   return (
-    <article className="border-e border-s">
+    <article className="lg:border-e lg:border-s">
       <header className="relative flex items-center border-b">
         <Link
           className={cn(
@@ -30,7 +30,9 @@ export function ProductArticle({product, children, nextProduct}: ProductArticleP
           <ChevronLeft className="ms-2 mt-icon size-4 stroke-1 transition-all duration-100 ease-in-out group-hover:inline-block group-hover:text-foreground" />
           Atrás
         </Link>
-        <H2 className="flex-grow border-none py-6 text-center text-4xl">{product.nombre}</H2>
+        <H2 className="ml-6 flex-grow border-none py-6 text-center text-4xl sm:ml-0">
+          {product.nombre}
+        </H2>
       </header>
       <div className="flex w-full flex-col items-center gap-y-6 pt-4 lg:hidden">
         <div className="flex w-full justify-between px-4">

--- a/src/modules/product/components/related-products.tsx
+++ b/src/modules/product/components/related-products.tsx
@@ -17,11 +17,14 @@ export function RelatedProducts({products}: RelatedProductsProps) {
   return (
     <ScrollArea className="w-full whitespace-nowrap">
       <ul
-        className={cn("mb-12 flex gap-8 overflow-x-auto pb-4", length < 2 ? "justify-center" : "")}
+        className={cn(
+          "mb-12 flex gap-4 overflow-x-auto pb-4 md:gap-8",
+          length < 2 ? "justify-center" : "",
+        )}
       >
         {products.map((related) => (
-          <li key={related.id} className="space-y-2">
-            <ProductLink className="w-28" product={related} ratio={1} />
+          <li key={related.id} className="w-1/2 flex-shrink-0 space-y-2 md:flex-shrink">
+            <ProductLink product={related} ratio={1} />
           </li>
         ))}
       </ul>


### PR DESCRIPTION
Se modificaron los estilos de las paginas: `HomePage()` y `ProductPage()` ; y los componentes: `<Header />` `<RelatedProducts />` `<ProductArticle />` `<VerticalImage />` con el fin de solucionar los anchos excedidos en mobile.

El componente principal que arrastraba esto era el `<Header />`, la modificacion de los demas fue para solucionar la pagina de producto individual que seguia con ese problema.

### Muestra con extension Responsive Viewer:

![{9A232B95-1BFD-41AC-833A-950A744C01FD}](https://github.com/user-attachments/assets/714f0426-3594-499b-9a6c-eb30c1d93139)

> Anteriormente nos marcaba la advertencia del exceso: 
> ![{E75C23E7-0FA1-4D9D-82B4-8FA527341013}](https://github.com/user-attachments/assets/a3231e59-76fa-4d09-afba-4c2faa424e29)
> 
