### PR TITLE
DEV-330/traer-instagram-y-whatsapp-de-strapi

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -3,10 +3,16 @@ import {Instagram} from "lucide-react";
 
 import {Whatsapp} from "./icons/whatsapp";
 
-import {cn} from "@/lib/utils";
+import {cn, toWhatsAppUrl} from "@/lib/utils";
 import {quicksand} from "@/fonts";
+import {getInstagram} from "@/modules/content/instagram";
+import {getWhatsApp} from "@/modules/content/whatsapp/api";
 
-export function Header() {
+export async function Header() {
+  const instagram = await getInstagram();
+  const {data: whatsapp} = await getWhatsApp();
+  const whatsAppUrl = toWhatsAppUrl(whatsapp.telefono);
+
   return (
     <div className="h-auto w-full border-b">
       <header className="flex h-min w-full justify-center overflow-hidden px-4 py-3 backdrop-blur md:px-12 lg:px-28">
@@ -36,14 +42,10 @@ export function Header() {
               <span className="px-2 tracking-widest">Nuestro trabajo</span>
               <div className="h-[0.15rem] w-full bg-transparent transition-colors duration-100 ease-in-out group-hover:bg-amber-400/65" />
             </Link>
-            <Link
-              className="group relative"
-              href="https://www.instagram.com/jad.marmoleria/"
-              target="_blank"
-            >
+            <Link className="group relative" href={instagram.url} target="_blank">
               <Instagram className="size-5" />
             </Link>
-            <Link className="group relative" href="https://wa.me/5491169101717" target="_blank">
+            <Link className="group relative" href={whatsAppUrl} target="_blank">
               <Whatsapp className="size-5" />
             </Link>
           </div>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -5,13 +5,18 @@ import {Whatsapp} from "./icons/whatsapp";
 
 import {getHero} from "@/modules/content/hero";
 import {Button} from "@/components/ui/button";
-import {cn} from "@/lib/utils";
+import {cn, toWhatsAppUrl} from "@/lib/utils";
 import {quicksand} from "@/fonts";
+import {getWhatsApp} from "@/modules/content/whatsapp/api";
 
 export async function Hero() {
   const {
     data: {imagenes, descripcion, titulo},
   } = await getHero();
+
+  const {data: whatsapp} = await getWhatsApp();
+
+  const whatsAppUrl = toWhatsAppUrl(whatsapp.telefono);
 
   const startH = titulo.indexOf("{");
   const endH = titulo.indexOf("}");
@@ -52,16 +57,14 @@ export async function Hero() {
         <H1 className="">{titleComponent()}</H1>
         <P className={cn("text-xl text-muted-foreground", quicksand.className)}>{descripcion}</P>
         <div className="mt-8 inline-flex gap-2">
-          <Link href="https://wa.me/5491169101717" target="_blank" className="flex items-center gap-2">
+          <Link className="flex items-center gap-2" href={whatsAppUrl} target="_blank">
             <Button className="w-48">
               Contactanos
               <Whatsapp className="size-7" />
             </Button>
           </Link>
           <Link href="/products">
-            <Button variant="outline">
-            Ver catálogo
-            </Button>
+            <Button variant="outline">Ver catálogo</Button>
           </Link>
         </div>
       </div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -29,3 +29,9 @@ export function isImageOrVideo(filePath: string): "image" | "video" | null {
     return null;
   }
 }
+
+export function toWhatsAppUrl(telefono: number) {
+  const url = "https://wa.me/" + telefono;
+
+  return url;
+}

--- a/src/modules/content/instagram/api.ts
+++ b/src/modules/content/instagram/api.ts
@@ -1,0 +1,17 @@
+import {Instagram, InstagramData} from "./types";
+
+import {QueryResponse, query} from "@/lib/strapi";
+
+export async function getInstagram(): Promise<Instagram> {
+  const res = await query<InstagramData>("instagram?populate[0]=cuenta", {
+    next: {tags: ["instagram"]},
+  });
+
+  const {
+    data: {
+      cuenta: {name, url},
+    },
+  } = res;
+
+  return {name, url};
+}

--- a/src/modules/content/instagram/index.ts
+++ b/src/modules/content/instagram/index.ts
@@ -1,0 +1,3 @@
+export * from "./api";
+
+export * from "./types";

--- a/src/modules/content/instagram/instagram.http
+++ b/src/modules/content/instagram/instagram.http
@@ -1,0 +1,5 @@
+#*
+#? Caso de uso:
+GET /api/instagram?populate[0]=cuenta
+Authorization: Bearer 375e18f79907e9fbc9de13d7c0e347651afb35eb08e359602899c3c4cad0bd27412b25387242a8f3206580f53950904b726da527d5ada6fc94c92e08c51817626be3c36438a972ab915ab4f5e3bf746eae591734403b5f0edfdf7a33f91b2a1af921f84a7c0e65836673e88cbf511412a56506dc2f500b33adc78d62039744c9
+Host: jad-marmoleria.colidevs.com

--- a/src/modules/content/instagram/types.ts
+++ b/src/modules/content/instagram/types.ts
@@ -1,0 +1,9 @@
+import {Data} from "@/lib/strapi";
+
+interface InstagramDTO {
+  cuenta: Instagram;
+}
+
+export type InstagramData = Data<InstagramDTO>;
+
+export type Instagram = {name: string; url: string};

--- a/src/modules/content/whatsapp/api.ts
+++ b/src/modules/content/whatsapp/api.ts
@@ -3,7 +3,9 @@ import {WhatsApp} from "./types";
 import {QueryResponse, query} from "@/lib/strapi";
 
 export async function getWhatsApp(): QueryResponse<WhatsApp> {
-  const res = await query<WhatsApp>("whatsapp");
+  const res = await query<WhatsApp>("whatsapp", {
+    next: {tags: ["whatsapp"]},
+  });
 
   return res;
 }

--- a/src/modules/content/whatsapp/api.ts
+++ b/src/modules/content/whatsapp/api.ts
@@ -1,0 +1,9 @@
+import {WhatsApp} from "./types";
+
+import {QueryResponse, query} from "@/lib/strapi";
+
+export async function getWhatsApp(): QueryResponse<WhatsApp> {
+  const res = await query<WhatsApp>("whatsapp");
+
+  return res;
+}

--- a/src/modules/content/whatsapp/types.ts
+++ b/src/modules/content/whatsapp/types.ts
@@ -1,0 +1,8 @@
+import {Data} from "@/lib/strapi";
+
+interface WhatsAppDTO {
+  telefono: number;
+  mensaje?: string;
+}
+
+export type WhatsApp = Data<WhatsAppDTO>;

--- a/src/modules/content/whatsapp/whatsapp.http
+++ b/src/modules/content/whatsapp/whatsapp.http
@@ -1,0 +1,4 @@
+#* Prueba de integración para el módulo de whatsapp
+GET /api/whatsapp
+Authorization: Bearer 375e18f79907e9fbc9de13d7c0e347651afb35eb08e359602899c3c4cad0bd27412b25387242a8f3206580f53950904b726da527d5ada6fc94c92e08c51817626be3c36438a972ab915ab4f5e3bf746eae591734403b5f0edfdf7a33f91b2a1af921f84a7c0e65836673e88cbf511412a56506dc2f500b33adc78d62039744c9
+Host: jad-marmoleria.colidevs.com

--- a/src/modules/product/components/product-article.tsx
+++ b/src/modules/product/components/product-article.tsx
@@ -5,19 +5,23 @@ import {ChevronDown, ChevronLeft} from "lucide-react";
 
 import {H2, P} from "@/components/typo";
 import {Button} from "@/components/ui/button";
-import {cn} from "@/lib/utils";
+import {cn, toWhatsAppUrl} from "@/lib/utils";
 import {Whatsapp} from "@/components/icons/whatsapp";
 import {IconLink} from "@/components/icon-link";
 import {IconNames} from "@/components/icons";
 import {NavProductButton} from "@/components/nav-button";
+import {getWhatsApp} from "@/modules/content/whatsapp/api";
 
 type ProductArticleProps = {
   product: Product;
   children?: React.ReactNode;
-nextProduct?: Product;
+  nextProduct?: Product;
 };
 
-export function ProductArticle({product, children, nextProduct}: ProductArticleProps) {
+export async function ProductArticle({product, children, nextProduct}: ProductArticleProps) {
+  const {data: whatsapp} = await getWhatsApp();
+  const whatsAppUrl = toWhatsAppUrl(whatsapp.telefono);
+
   return (
     <article className="lg:border-e lg:border-s">
       <header className="relative flex items-center border-b">
@@ -52,7 +56,7 @@ export function ProductArticle({product, children, nextProduct}: ProductArticleP
             variant="rightString"
           />
         </div>
-        <Link href="/" target="_blank">
+        <Link href={whatsAppUrl} target="_blank">
           <Button className="btn btn-primary ">
             Sacate las dudas
             <Whatsapp className="size-5" />
@@ -113,9 +117,13 @@ export function ProductArticle({product, children, nextProduct}: ProductArticleP
             </ul>
             <footer className="self-center lg:self-end">
               <div className="flex justify-end py-6">
-                <Link className="group relative flex items-center gap-2" href="https://wa.me/5491169101717" target="_blank">
-                 <Button className="btn btn-primary">
-                   Sacate las dudas
+                <Link
+                  className="group relative flex items-center gap-2"
+                  href={whatsAppUrl}
+                  target="_blank"
+                >
+                  <Button className="btn btn-primary">
+                    Sacate las dudas
                     <Whatsapp className="size-5" />
                   </Button>
                 </Link>

--- a/src/modules/projects/components/project-article.tsx
+++ b/src/modules/projects/components/project-article.tsx
@@ -3,20 +3,25 @@ import {BlocksRenderer, type BlocksContent} from "@strapi/blocks-react-renderer"
 import {ChevronDown, ChevronLeft} from "lucide-react";
 
 import {Project} from "../types";
+import {BlocksRendererWrapper} from "./blocksrenderer-wrapper";
 
 import {H1, H2, H3, H4, P} from "@/components/typo";
 import {Button} from "@/components/ui/button";
 import {Whatsapp} from "@/components/icons/whatsapp";
-import {cn} from "@/lib/utils";
-import { BlocksRendererWrapper } from "./blocksrenderer-wrapper";
+import {cn, toWhatsAppUrl} from "@/lib/utils";
+import {getWhatsApp} from "@/modules/content/whatsapp/api";
 
 type ProjectArticleProps = {
   project: Project;
   children?: React.ReactNode;
 };
 
-export function ProjectArticle({project, children}: ProjectArticleProps) {
+export async function ProjectArticle({project, children}: ProjectArticleProps) {
   const content: BlocksContent = project.descripcion as unknown as BlocksContent;
+  const {data: whatsapp} = await getWhatsApp();
+
+  const whatsAppUrl = toWhatsAppUrl(whatsapp.telefono);
+
   return (
     <article className="border-e border-s">
       <header className="flex items-center justify-between gap-4 border-b">
@@ -32,7 +37,7 @@ export function ProjectArticle({project, children}: ProjectArticleProps) {
         <H2 className="flex-1 border-none py-6 md:text-center text-4xl">{project.nombre}</H2>
       </header>
       <div className="pt-4 lg:hidden flex flex-col items-center w-full gap-y-6">
-        <Link className="group relative flex items-center gap-2" href="https://wa.me/5491169101717" target="_blank">
+        <Link className="group relative flex items-center gap-2" href={whatsAppUrl} target="_blank">
            <Button className="btn btn-primary">
               Sacate las dudas
              <Whatsapp className="size-5" />
@@ -51,7 +56,11 @@ export function ProjectArticle({project, children}: ProjectArticleProps) {
           <div className="inline-flex w-full justify-center lg:justify-end">
             <footer className="self-end">
               <div className="flex justify-end py-6">
-                <Link className="group relative flex items-center gap-2" href="https://wa.me/5491169101717" target="_blank">
+                <Link
+                  className="group relative flex items-center gap-2"
+                  href={whatsAppUrl}
+                  target="_blank"
+                >
                  <Button className="btn btn-primary">
                     Sacate las dudas
                     <Whatsapp className="size-5" />


### PR DESCRIPTION
Se agregaron los modulos de Instagram y WhatsApp para poder traer la informacion de Strapi.

Se modificaron las rutas a Instagram y WhatsApp en los componentes: `<Hero />` `<Header />` `<ProjectArticle />` `<ProductArticle />` por las traidas de Strapi