### PR TITLE
Fix layout shift

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -105,6 +105,9 @@
   * {
     @apply border-border;
   }
+  html {
+     scrollbar-gutter: stable;
+  }
   body {
     @apply bg-background text-foreground;
   }


### PR DESCRIPTION
Agregado de la propiedad `scrollbar-gutter: stable` al elemento html en el archivo global de estilos, esta propiedad preserva el espacio del scrollbar en todas las paginas y previene el layout shift