### PR TITLE
Astridnaivirt22/dev 364 agregar props noopener noreferrer a links de wsp e ig

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -44,10 +44,20 @@ export async function Header() {
               <span className="px-2 tracking-widest">{header.projects}</span>
               <div className="h-[0.15rem] w-full bg-transparent transition-colors duration-100 ease-in-out group-hover:bg-amber-400/65" />
             </Link>
-            <Link className="group relative" href={instagram.url} target="_blank">
+            <Link
+              className="group relative"
+              href={instagram.url}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
               <Instagram className="size-5" />
             </Link>
-            <Link className="group relative" href={whatsAppUrl} target="_blank">
+            <Link
+              className="group relative"
+              href={whatsAppUrl}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
               <Whatsapp className="size-5" />
             </Link>
           </div>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -57,7 +57,12 @@ export async function Hero() {
         <H1 className="">{titleComponent()}</H1>
         <P className={cn("text-xl text-muted-foreground", quicksand.className)}>{descripcion}</P>
         <div className="mt-8 inline-flex gap-2">
-          <Link className="flex items-center gap-2" href={whatsAppUrl} target="_blank">
+          <Link
+            className="flex items-center gap-2"
+            href={whatsAppUrl}
+            rel="noopener noreferrer"
+            target="_blank"
+          >
             <Button className="w-48">
               Contactanos
               <Whatsapp className="size-7" />

--- a/src/modules/product/components/product-article.tsx
+++ b/src/modules/product/components/product-article.tsx
@@ -57,7 +57,7 @@ export async function ProductArticle({product, children, nextProduct}: ProductAr
             variant="rightString"
           />
         </div>
-        <Link href={whatsAppUrl} target="_blank">
+        <Link href={whatsAppUrl} rel="noopener noreferrer" target="_blank">
           <Button className="btn btn-primary ">
             Sacate las dudas
             <Whatsapp className="size-5" />
@@ -121,6 +121,7 @@ export async function ProductArticle({product, children, nextProduct}: ProductAr
                 <Link
                   className="group relative flex items-center gap-2"
                   href={whatsAppUrl}
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                   <Button className="btn btn-primary">

--- a/src/modules/projects/components/project-article.tsx
+++ b/src/modules/projects/components/project-article.tsx
@@ -64,6 +64,7 @@ export async function ProjectArticle({project, children}: ProjectArticleProps) {
                 >
                  <Button className="btn btn-primary">
                     Sacate las dudas
+                  rel="noopener noreferrer"
                     <Whatsapp className="size-5" />
                   </Button>
                 </Link>


### PR DESCRIPTION
Se agregaron las propiedades `rel` `"noopener"` `"noreferrer"` a los `<Link />` de WhatsApp e Instagram en los componentes: `<Hero />` `<Header />` `<ProductArticle />` `<ProjectArticle />`