### PR TITLE
Astridnaivirt22/dev 347 eliminar bordes proyecto individual mobile

### DIFF
--- a/src/modules/projects/components/project-article.tsx
+++ b/src/modules/projects/components/project-article.tsx
@@ -60,11 +60,11 @@ export async function ProjectArticle({project, children}: ProjectArticleProps) {
                 <Link
                   className="group relative flex items-center gap-2"
                   href={whatsAppUrl}
+                  rel="noopener noreferrer"
                   target="_blank"
                 >
                  <Button className="btn btn-primary">
                     Sacate las dudas
-                  rel="noopener noreferrer"
                     <Whatsapp className="size-5" />
                   </Button>
                 </Link>

--- a/src/modules/projects/components/project-article.tsx
+++ b/src/modules/projects/components/project-article.tsx
@@ -37,6 +37,7 @@ export async function ProjectArticle({project, children}: ProjectArticleProps) {
         </Link>
         <H2 className="flex-1 border-none py-6 md:text-center text-4xl">{project.nombre}</H2>
       </header>
+      <div className="flex w-full flex-col items-center gap-y-6 pt-4 lg:hidden">
         <Link
           className="group relative flex items-center gap-2"
           href={whatsAppUrl}

--- a/src/modules/projects/components/project-article.tsx
+++ b/src/modules/projects/components/project-article.tsx
@@ -23,7 +23,7 @@ export async function ProjectArticle({project, children}: ProjectArticleProps) {
   const whatsAppUrl = toWhatsAppUrl(whatsapp.telefono);
 
   return (
-    <article className="border-e border-s">
+    <article className="lg:border-e lg:border-s">
       <header className="flex items-center justify-between gap-4 border-b">
         <Link
           prefetch

--- a/src/modules/projects/components/project-article.tsx
+++ b/src/modules/projects/components/project-article.tsx
@@ -37,8 +37,12 @@ export async function ProjectArticle({project, children}: ProjectArticleProps) {
         </Link>
         <H2 className="flex-1 border-none py-6 md:text-center text-4xl">{project.nombre}</H2>
       </header>
-      <div className="pt-4 lg:hidden flex flex-col items-center w-full gap-y-6">
-        <Link className="group relative flex items-center gap-2" href={whatsAppUrl} target="_blank">
+        <Link
+          className="group relative flex items-center gap-2"
+          href={whatsAppUrl}
+          rel="noopener noreferrer"
+          target="_blank"
+        >
            <Button className="btn btn-primary">
               Sacate las dudas
              <Whatsapp className="size-5" />


### PR DESCRIPTION
Modificado del layout de `<ProjectArticle />` para que los bordes de los costados sean visibles a partir de pantallas lg.

Arreglo de las propiedades rel del `<Link />` de WhatsApp que estaba mal posicionado.

Arreglo de una etiqueta `<div />` que faltaba la apertura, por seleccionar mal los cambios en el commit de la rama anterior.