### PR TITLE
Astridnaivirt22/dev 335 mejorar width en producto individual mobile

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,6 +32,9 @@ export default function RootLayout({children}: {children: React.ReactNode}) {
   return (
     <ViewTransitions>
       <html className="scroll-smooth" lang="es">
+        <head>
+          <meta content="width=device-width, initial-scale=1.0" name="viewport" />
+        </head>
         <body className="scrollbar border-border bg-background text-foreground">
           <div
             className={cn(

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -28,20 +28,20 @@ export async function Header() {
           </Link>
           <div
             className={cn(
-              "m-auto inline-flex w-full max-w-3xl justify-center gap-2 rounded py-1 font-semibold md:gap-4",
+              "m-auto inline-flex w-full max-w-3xl justify-center gap-4 rounded py-1 font-semibold",
               quicksand.className,
             )}
           >
             <Link prefetch className="group relative" href="/">
-              <span className="px-2 tracking-widest">{header.home}</span>
+              <span className="tracking-widest sm:px-2">{header.home}</span>
               <div className="h-[0.15rem] w-full bg-transparent transition-colors duration-100 ease-in-out group-hover:bg-amber-400/65" />
             </Link>
             <Link prefetch className="group relative" href="/products">
-              <span className="px-2 tracking-widest">{header.products}</span>
+              <span className="tracking-widest sm:px-2">{header.products}</span>
               <div className="h-[0.15rem] w-full bg-transparent transition-colors duration-100 ease-in-out group-hover:bg-amber-400/65" />
             </Link>
             <Link prefetch className="group relative" href="/projects">
-              <span className="px-2 tracking-widest">{header.projects}</span>
+              <span className="tracking-widest sm:px-2">{header.projects}</span>
               <div className="h-[0.15rem] w-full bg-transparent transition-colors duration-100 ease-in-out group-hover:bg-amber-400/65" />
             </Link>
             <Link

--- a/src/components/vertical-carousel.tsx
+++ b/src/components/vertical-carousel.tsx
@@ -50,8 +50,8 @@ export function VerticalCarousel({images}: VerticalCarouselProps) {
           {current} / {count}
         </span>
       </div>
-      <CarouselPrevious className="rounded" />
-      <CarouselNext className="rounded" />
+      <CarouselPrevious className="hidden rounded sm:flex" />
+      <CarouselNext className="hidden rounded sm:flex" />
     </Carousel>
   );
 }


### PR DESCRIPTION
Se mejoro la responsividad ocultando los componentes `<CarouselPrevious />` y `<CarouselNext/>` en pantallas chicas ya que estos empeoraban el desborde del contenido, a partir de pantallas `md` se muestran. Tambien se actualizaron los estilos del header y se agregó la meta etiqueta `viewport` dentro del `<head />` para asegurar que la página se adapte correctamente a diferentes tamaños de pantalla y se muestre con un zoom inicial del 100%.