### PR TITLE
Astridnaivirt22/dev 462 mensaje de wpp x producto

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -10,7 +10,7 @@ import {api} from "@/api";
 export async function Header() {
   const instagram = await api.instagram.get();
   const whatsapp = await api.whatsapp.get();
-  const whatsAppUrl = toWhatsAppUrl(whatsapp.telefono);
+  const whatsAppUrl = toWhatsAppUrl(whatsapp);
   const header = await api.header.get();
 
   return (

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -14,7 +14,7 @@ export async function Hero() {
 
   const whatsapp = await api.whatsapp.get();
 
-  const whatsAppUrl = toWhatsAppUrl(whatsapp.telefono);
+  const whatsAppUrl = toWhatsAppUrl(whatsapp);
 
   const startH = titulo.indexOf("{");
   const endH = titulo.indexOf("}");

--- a/src/components/home-header.tsx
+++ b/src/components/home-header.tsx
@@ -11,7 +11,7 @@ import {api} from "@/api";
 export async function HomeHeader() {
   const instagram = await api.instagram.get();
   const whatsapp = await api.whatsapp.get();
-  const whatsAppUrl = toWhatsAppUrl(whatsapp.telefono);
+  const whatsAppUrl = toWhatsAppUrl(whatsapp);
   const header = await api.header.get();
 
   const startH = header.title.indexOf("{");

--- a/src/components/main-header.tsx
+++ b/src/components/main-header.tsx
@@ -12,7 +12,7 @@ import {api} from "@/api";
 export async function MainHeader() {
   const instagram = await api.instagram.get();
   const whatsapp = await api.whatsapp.get();
-  const whatsAppUrl = toWhatsAppUrl(whatsapp.telefono);
+  const whatsAppUrl = toWhatsAppUrl(whatsapp);
   const header = await api.header.get();
 
   const startH = header.title.indexOf("{");

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,6 +2,9 @@ import * as path from "path";
 
 import {clsx, type ClassValue} from "clsx";
 import {twMerge} from "tailwind-merge";
+import { WhatsApp } from "@/modules/content/whatsapp";
+import { Product } from "@/modules/product";
+import { Project } from "@/modules/projects";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
@@ -30,8 +33,33 @@ export function isImageOrVideo(filePath: string): "image" | "video" | null {
   }
 }
 
-export function toWhatsAppUrl(telefono: number) {
-  const url = "https://wa.me/" + telefono;
+export function toWhatsAppUrl(whatsapp: WhatsApp, object?: Product | Project, type?: "producto" | "proyecto"): string {
+
+  const message = createWhatsAppMessage(whatsapp.mensaje, object, type);
+
+  const url = "https://api.whatsapp.com/send?phone=" + whatsapp.telefono + "&text=" + encodeURIComponent(message);
 
   return url;
+}
+
+export function createWhatsAppMessage(message: string, object?: Product | Project, type?: string): string {
+
+  if(message.length === 0) {
+    return "";
+  }
+
+  const start = message.indexOf("{");
+  const end = message.indexOf("}");
+
+  const startM = message.split("{")[0];
+  const endM = message.split("}")[1];
+
+  if(!object){
+    return startM + endM;
+  }
+
+  const insertProduct = message.substring(start + 1, end) + " " + type + " " + object.nombre + ",";
+  const completeMessage = `${startM}${insertProduct}${endM}`;
+
+  return completeMessage;
 }

--- a/src/modules/product/components/product-article.tsx
+++ b/src/modules/product/components/product-article.tsx
@@ -18,9 +18,10 @@ type ProductArticleProps = {
   nextProduct?: Product;
 };
 
+
 export async function ProductArticle({product, children, nextProduct}: ProductArticleProps) {
   const whatsapp = await api.whatsapp.get();
-  const whatsAppUrl = toWhatsAppUrl(whatsapp.telefono);
+  const whatsAppUrl = toWhatsAppUrl(whatsapp, product, "producto");
 
   return (
     <article className="w-full lg:border-e lg:border-s">

--- a/src/modules/projects/components/project-article.tsx
+++ b/src/modules/projects/components/project-article.tsx
@@ -21,7 +21,7 @@ export async function ProjectArticle({project, children}: ProjectArticleProps) {
   const content: BlocksContent = project.descripcion as unknown as BlocksContent;
   const whatsapp = await api.whatsapp.get();
 
-  const whatsAppUrl = toWhatsAppUrl(whatsapp.telefono);
+  const whatsAppUrl = toWhatsAppUrl(whatsapp, project, "proyecto");
 
   return (
     <article className="w-full lg:border-e lg:border-s">


### PR DESCRIPTION
### Strapi

Con la misma lógica que usamos en el título para hacer el Highlight, el fragmento de texto a agregar en el caso de los productos/proyectos, debe ponerse entre llaves {}, luego en código se agrega el tipo y nombre.

### Código

Se añadió una nueva función a lib > utils para generar el mensaje correcto para WhatsApp, esta consta de recibir el mensaje puesto en Strapi:

- Si no existe, devuelve "".
- Si no se manda un objeto Product o Project por parámetro, lo devuelve sin llaves.
- Si existe el objeto, se agrega el mensaje entre llaves más el tipo "producto | "proyecto" y su nombre.

### Ejemplo
_"Hola, vi su página web y {me interesó el} quería hacer una consulta sobre trabajos en mármol. ¡Gracias!"_

**Default:** _"Hola, vi su página web y quería hacer una consulta sobre trabajos en mármol. ¡Gracias!"_

**En un producto:** _"Hola, vi su página web y **me interesó el producto x** quería hacer una consulta sobre trabajos en mármol. ¡Gracias!"_

**En un proyecto:** _"Hola, vi su página web y **me interesó el proyecto x** quería hacer una consulta sobre trabajos en mármol. ¡Gracias!"_